### PR TITLE
feat:: add opentelemetry-python use

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 ├── opentelemetry-collector --------------------- 为 otel 官方采集器用法
 ├── opentelemetry-javaagent --------------------- 为 opentelemetry-javaagent 各版本jar，方便下载使用
 ├── opentelemetry-js ---------------------------- 主要演示 opentelemetry 提供的前端RUM功能以及如何跟后端APM结合使用，完成全链路追踪
-├── [opentelemetry-python](/observable-demo/blob/main/opentelemetry-python/README.MD) ------------------------ opentelemetry python 使用方式（手动、自动），后端采用了 grafana tempo（jaeger gRPC/thrift 协议）
+├── opentelemetry-python ------------------------ opentelemetry python 使用方式（手动、自动），后端采用了 grafana tempo（jaeger gRPC/thrift 协议）
 ├── otel-collector-demo 
 ├── springboot-client --------------------------- Springboot 客户端
 ├── springboot-ddtrace-server ------------------- 主要介绍datadog 的 apm 组件 ddtrace 的使用方法（基于 Springboot 应用）

--- a/README.md
+++ b/README.md
@@ -15,28 +15,21 @@
 - Exporter: JaegerExporter \ OtlpExporter \ ZipkinExporter
 
 ## 项目介绍
-springboot-opentracing-jaeger ：介绍 `jaeger` 用法（基于springboot 应用）
-
-opentelemetry-javaagent :  为 opentelemetry-javaagent 各版本jar，方便下载使用。
-
-springboot-opentelemetry-jaeger-server : 介绍 `opentelemetry` 的 `jaegerExporter` 用法（基于Springboot分布式应用服务端）
-
-springboot-opentelemetry-jaeger-client : 介绍 `opentelemetry` 的 `jaegerExporter` 用法（基于Springboot分布式应用客户端）
-
-springboot-opentelemetry-otlp-server : 介绍 `opentelemetry` 的 `otlpExporter` 用法（基于Springboot分布式应用服务端）
-
-springboot-opentelemetry-otlp-client : 介绍 `opentelemetry` 的 `otlpExporter` 用法（基于Springboot分布式应用客户端）
-
-images: 主要是各个项目使用的image 集合
-
-apm : 主要是常见apm 安装使用手册
-
-springboot-ddtrace-server ：主要介绍`datadog` 的 apm 组件 `ddtrace` 的使用方法（基于 Springboot 应用）
-
-opentelemetry-collector ： 为 otel 官方采集器用法
-
-springboot-client ： Springboot 客户端
-
-springboot-server ： Springboot 服务端，结合客户端一起使用，方便查看分布式应用链路情况。
-
-opentelemetry-js ： 主要演示 opentelemetry 提供的前端RUM功能以及如何跟后端APM结合使用，完成全链路追踪。
+```shell
+.
+├── apm ----------------------------------------- 主要是常见apm 安装使用手册
+├── images -------------------------------------- 主要是各个项目使用的image 集合
+├── opentelemetry-collector --------------------- 为 otel 官方采集器用法
+├── opentelemetry-javaagent --------------------- 为 opentelemetry-javaagent 各版本jar，方便下载使用
+├── opentelemetry-js ---------------------------- 主要演示 opentelemetry 提供的前端RUM功能以及如何跟后端APM结合使用，完成全链路追踪
+├── [opentelemetry-python](/observable-demo/blob/main/opentelemetry-python/README.MD) ------------------------ opentelemetry python 使用方式（手动、自动），后端采用了 grafana tempo（jaeger gRPC/thrift 协议）
+├── otel-collector-demo 
+├── springboot-client --------------------------- Springboot 客户端
+├── springboot-ddtrace-server ------------------- 主要介绍datadog 的 apm 组件 ddtrace 的使用方法（基于 Springboot 应用）
+├── springboot-opentelemetry-jaeger-client ------ 介绍 opentelemetry 的 jaegerExporter 用法（基于Springboot分布式应用客户端）
+├── springboot-opentelemetry-jaeger-server ------ 介绍 opentelemetry 的 jaegerExporter 用法（基于Springboot分布式应用服务端）
+├── springboot-opentelemetry-otlp-client -------- 介绍 opentelemetry 的 otlpExporter 用法（基于Springboot分布式应用客户端）
+├── springboot-opentelemetry-otlp-server -------- 介绍 opentelemetry 的 otlpExporter 用法（基于Springboot分布式应用服务端）
+├── springboot-opentracing-jaeger --------------- 介绍 jaeger 用法（基于springboot 应用）
+└── springboot-server --------------------------- Springboot 服务端，结合客户端一起使用，方便查看分布式应用链路情况
+```

--- a/opentelemetry-python/Dockerfile
+++ b/opentelemetry-python/Dockerfile
@@ -1,0 +1,12 @@
+FROM tonycody/python3-otel:1.0
+
+ENV OTEL_WORKDIR=/opentelemetry
+WORKDIR $OTEL_WORKDIR
+
+COPY automatic-instrumentation/ automatic-instrumentation/
+COPY manual-instrumentation/ manual-instrumentation/
+COPY bootstrap.sh .
+
+RUN ln -s $OTEL_WORKDIR/bootstrap.sh /usr/local/bin/entrypoint
+
+CMD ["entrypoint"]

--- a/opentelemetry-python/README.md
+++ b/opentelemetry-python/README.md
@@ -75,4 +75,5 @@ python3-otel-example_1  | }
 http://localhost:3000/
 ```
 > 查询时需要去掉`trace_id`前面的`0x`
+
 ![](http://cdn.0512.host/images/20220518181013.png)

--- a/opentelemetry-python/README.md
+++ b/opentelemetry-python/README.md
@@ -1,22 +1,22 @@
 # 目录结构说明
 ```shell
 .
-├── automatic-instrumentation ------------------- [自动仪表](https://opentelemetry.io/docs/instrumentation/python/automatic/)，使用:jaeger thrift http
-│   ├── client.py ------------------------- 客户端，执行后会调用服务端，端口：8082
-│   ├── client.sh ------------------------- 客户端，执行脚本
-│   ├── server.py ------------------------- 服务端，为客户端提供服务，模拟常规接口调用
-│   └── server.sh ------------------------- 服务端，执行脚本
+├── automatic-instrumentation ------------------- 自动仪表(https://opentelemetry.io/docs/instrumentation/python/automatic/)，使用:jaeger thrift http
+│  ├── client.py -------------------------------- 客户端，执行后会调用服务端，端口：8082
+│  ├── client.sh -------------------------------- 客户端，执行脚本
+│  ├── server.py -------------------------------- 服务端，为客户端提供服务，模拟常规接口调用
+│  └── server.sh -------------------------------- 服务端，执行脚本
 ├── bootstrap.sh -------------------------------- 启动脚本，分别调用自动仪表、手动仪表相关的执行 shell 脚本
 ├── datasource.yaml ----------------------------- grafana 源数据源配置文件
 ├── docker-compose.yaml ------------------------- 整个模拟环境的 docker 编排文件
-├── Dockerfile ---------------------------------- python 运行环境容器，定制r
-├── manual-instrumentation
-│   ├── jaeger_exporter_grpc.py
-│   ├── jaeger_exporter_grpc.sh
-│   ├── jaeger_exporter_thrift.py
-│   └── jaeger_exporter_thrift.sh
-├── README.md
-└── tempo.yaml
+├── Dockerfile ----------------------------------- python 运行环境容器，已包含相关 pip 包的定制容器
+├── manual-instrumentation ---------------------- 手动仪表(https://opentelemetry.io/docs/instrumentation/python/manual/)，使用:jaeger gRPC/thrift http
+│  ├── jaeger_exporter_grpc.py ------------------ Jaeger gRPC 导出器
+│  ├── jaeger_exporter_grpc.sh ------------------ Jaeger gRPC 导出器，执行脚本
+│  ├── jaeger_exporter_thrift.py ---------------- Jaeger Thrift 导出器
+│  └── jaeger_exporter_thrift.sh ---------------- Jaeger Thrift 导出器，执行脚本
+├── README.md ----------------------------------- 说明文档
+└── tempo.yaml ---------------------------------- Tempo 容器配置文件
 ```
 
 # 镜像说明

--- a/opentelemetry-python/README.md
+++ b/opentelemetry-python/README.md
@@ -77,3 +77,9 @@ http://localhost:3000/
 > 查询时需要去掉`trace_id`前面的`0x`
 
 ![](http://cdn.0512.host/images/20220518181013.png)
+
+> 遗留问题说明：
+> 
+> 1.opentelemetry-instrument 不支持 insecure 参数已提 [PR](https://github.com/open-telemetry/opentelemetry-python/pull/2696)
+> 
+> 2.python 导出使用 gRPC 协议时，导出服务端为 Tempo（1.4.1）版本时，`trace_id`能查询，但无数据。已提 [issue](https://github.com/grafana/tempo/issues/1432)

--- a/opentelemetry-python/README.md
+++ b/opentelemetry-python/README.md
@@ -1,0 +1,78 @@
+# 目录结构说明
+```shell
+.
+├── automatic-instrumentation ------------------- [自动仪表](https://opentelemetry.io/docs/instrumentation/python/automatic/)，使用:jaeger thrift http
+│   ├── client.py ------------------------- 客户端，执行后会调用服务端，端口：8082
+│   ├── client.sh ------------------------- 客户端，执行脚本
+│   ├── server.py ------------------------- 服务端，为客户端提供服务，模拟常规接口调用
+│   └── server.sh ------------------------- 服务端，执行脚本
+├── bootstrap.sh -------------------------------- 启动脚本，分别调用自动仪表、手动仪表相关的执行 shell 脚本
+├── datasource.yaml ----------------------------- grafana 源数据源配置文件
+├── docker-compose.yaml ------------------------- 整个模拟环境的 docker 编排文件
+├── Dockerfile ---------------------------------- python 运行环境容器，定制r
+├── manual-instrumentation
+│   ├── jaeger_exporter_grpc.py
+│   ├── jaeger_exporter_grpc.sh
+│   ├── jaeger_exporter_thrift.py
+│   └── jaeger_exporter_thrift.sh
+├── README.md
+└── tempo.yaml
+```
+
+# 镜像说明
+```shell
+docker pull tonycody/python3-otel:1.0
+```
+#该镜像已经安装了以下包信息：
+```shell
+pip install opentelemetry-sdk && \
+pip install opentelemetry-api && \
+pip install opentelemetry-distro && \
+pip install opentelemetry-instrumentation-flask && \
+pip install flask && \
+pip install requests && \
+pip install opentelemetry-exporter-jaeger-proto-grpc && \
+pip install opentelemetry-exporter-jaeger-thrift
+```
+# 使用方式
+```shell
+docker-compose up | grep python3-otel-example
+```
+## 执行结果说明
+```shell
+python3-otel-example_1  |  Starting Client... 
+python3-otel-example_1  | {
+python3-otel-example_1  |     "name": "client-server",
+python3-otel-example_1  |     "context": {
+python3-otel-example_1  |         "trace_id": "0xe8d7f6bc7f85d5068c9d60e5c3f5a07a",
+python3-otel-example_1  |         "span_id": "0x70da62b26ebdfa3c",
+python3-otel-example_1  |         "trace_state": "[]"
+python3-otel-example_1  |     },
+python3-otel-example_1  |     "kind": "SpanKind.INTERNAL",
+python3-otel-example_1  |     "parent_id": "0x5ca981a4d24c4d18",
+python3-otel-example_1  |     "start_time": "2022-05-18T10:08:57.349127Z",
+python3-otel-example_1  |     "end_time": "2022-05-18T10:08:57.396925Z",
+python3-otel-example_1  |     "status": {
+python3-otel-example_1  |         "status_code": "UNSET"
+python3-otel-example_1  |     },
+python3-otel-example_1  |     "attributes": {},
+python3-otel-example_1  |     "events": [],
+python3-otel-example_1  |     "links": [],
+python3-otel-example_1  |     "resource": {
+python3-otel-example_1  |         "telemetry.sdk.language": "python",
+python3-otel-example_1  |         "telemetry.sdk.name": "opentelemetry",
+python3-otel-example_1  |         "telemetry.sdk.version": "1.12.0rc1",
+python3-otel-example_1  |         "service.name": "python-thrift-client-automatic",
+python3-otel-example_1  |         "telemetry.auto.version": "0.31b0"
+python3-otel-example_1  |     }
+python3-otel-example_1  | }
+```
+其中的`trace_id`为链路 id，如上：`0xe8d7f6bc7f85d5068c9d60e5c3f5a07a`
+
+## 查询链路
+```shell
+# 打开 grafana
+http://localhost:3000/
+```
+> 查询时需要去掉`trace_id`前面的`0x`
+![](http://cdn.0512.host/images/20220518181013.png)

--- a/opentelemetry-python/automatic-instrumentation/client.py
+++ b/opentelemetry-python/automatic-instrumentation/client.py
@@ -1,0 +1,34 @@
+from sys import argv
+
+from requests import get
+
+from opentelemetry import trace
+from opentelemetry.propagate import inject
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import (
+    BatchSpanProcessor,
+    ConsoleSpanExporter,
+)
+
+trace.set_tracer_provider(TracerProvider())
+tracer = trace.get_tracer_provider().get_tracer(__name__)
+
+trace.get_tracer_provider().add_span_processor(
+    BatchSpanProcessor(ConsoleSpanExporter())
+)
+
+
+assert len(argv) == 2
+
+with tracer.start_as_current_span("client"):
+
+    with tracer.start_as_current_span("client-server"):
+        headers = {}
+        inject(headers)
+        requested = get(
+            "http://localhost:8082/server_request",
+            params={"param": argv[1]},
+            headers=headers,
+        )
+
+        assert requested.status_code == 200

--- a/opentelemetry-python/automatic-instrumentation/client.sh
+++ b/opentelemetry-python/automatic-instrumentation/client.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+opentelemetry-instrument \
+--exporter_jaeger_endpoint http://tempo:14268/api/traces?format=jaeger.thrift \
+--service_name python-thrift-client-automatic \
+--traces_exporter jaeger_thrift \
+python $OTEL_WORKDIR/automatic-instrumentation/client.py testing

--- a/opentelemetry-python/automatic-instrumentation/server.py
+++ b/opentelemetry-python/automatic-instrumentation/server.py
@@ -1,0 +1,29 @@
+from flask import Flask, request
+from requests import get
+
+from opentelemetry import trace
+from opentelemetry.propagate import inject
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import (
+    BatchSpanProcessor,
+    ConsoleSpanExporter,
+)
+
+trace.set_tracer_provider(TracerProvider())
+tracer = trace.get_tracer_provider().get_tracer(__name__)
+
+trace.get_tracer_provider().add_span_processor(
+    BatchSpanProcessor(ConsoleSpanExporter())
+)
+
+app = Flask(__name__)
+
+
+@app.route("/server_request")
+def server_request():
+    with tracer.start_as_current_span("server"):
+        print(request.args.get("param"))
+        return "served"
+
+if __name__ == "__main__":
+    app.run(port=8082)

--- a/opentelemetry-python/automatic-instrumentation/server.sh
+++ b/opentelemetry-python/automatic-instrumentation/server.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+opentelemetry-instrument \
+--exporter_jaeger_endpoint http://tempo:14268/api/traces?format=jaeger.thrift \
+--service_name python-thrift-server-automatic \
+--traces_exporter jaeger_thrift,console \
+python $OTEL_WORKDIR/automatic-instrumentation/server.py

--- a/opentelemetry-python/bootstrap.sh
+++ b/opentelemetry-python/bootstrap.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+echo -e "\033[41;37m ----------- Starting the sample automatic-instrumentation ----------- \033[0m"
+echo -e "\033[41;33m Starting Server... \033[0m"
+. $OTEL_WORKDIR/automatic-instrumentation/server.sh 2>&1 &
+sleep 5s
+echo -e "\033[41;33m Starting Client... \033[0m"
+. $OTEL_WORKDIR/automatic-instrumentation/client.sh
+
+echo -e "\033[41;37m ----------- Starting the sample manual-instrumentation ----------- \033[0m"
+echo -e "\033[41;33m Starting jaeger exporter grpc... \033[0m"
+. $OTEL_WORKDIR/manual-instrumentation/jaeger_exporter_grpc.sh
+echo -e "\033[41;33m Starting jaeger exporter thrift... \033[0m"
+. $OTEL_WORKDIR/manual-instrumentation/jaeger_exporter_thrift.sh

--- a/opentelemetry-python/docker-compose.yaml
+++ b/opentelemetry-python/docker-compose.yaml
@@ -1,0 +1,34 @@
+version: "3.8"
+services:
+  tempo:
+    image: grafana/tempo:1.4.1
+    command: ["-config.file=/etc/tempo.yaml"]
+    volumes:
+      - ./tempo.yaml:/etc/tempo.yaml
+      - ./data/tempo:/tmp/tempo
+    ports:
+      - "14268:14268"  # jaeger ingest, Jaeger - Thrift HTTP
+      - "14250:14250"  # Jaeger - GRPC
+      - "3200:3200"    # Tempo
+  grafana:
+    image: grafana/grafana:8.5.0
+    user: "0"
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_NAME=Main Org.
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+    volumes:
+      - ./datasource.yaml:/etc/grafana/provisioning/datasources/datasource.yaml
+    depends_on:
+      - tempo
+  python3-otel-example:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: python3-otel-example:1.0
+    depends_on:
+      - grafana

--- a/opentelemetry-python/manual-instrumentation/jaeger_exporter_grpc.py
+++ b/opentelemetry-python/manual-instrumentation/jaeger_exporter_grpc.py
@@ -1,0 +1,44 @@
+import time
+
+from opentelemetry import trace
+from opentelemetry.exporter.jaeger.proto.grpc import JaegerExporter
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import (BatchSpanProcessor,ConsoleSpanExporter)
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+
+trace.set_tracer_provider(TracerProvider(
+    resource=Resource.create({SERVICE_NAME: "python-grpc-manual"})
+    ))
+tracer = trace.get_tracer(__name__)
+
+jaeger_exporter = JaegerExporter(
+     collector_endpoint="tempo:14250",
+     insecure=True,
+)
+
+trace.get_tracer_provider().add_span_processor(
+    BatchSpanProcessor(ConsoleSpanExporter())
+)
+
+trace.get_tracer_provider().add_span_processor(
+    BatchSpanProcessor(jaeger_exporter)
+)
+
+# create some spans for testing
+with tracer.start_as_current_span("foo") as foo:
+    time.sleep(0.1)
+    foo.set_attribute("my_atribbute", True)
+    foo.add_event("event in foo", {"name": "foo1"})
+    with tracer.start_as_current_span(
+        "bar", links=[trace.Link(foo.get_span_context())]
+    ) as bar:
+        time.sleep(0.2)
+        bar.set_attribute("speed", 100.0)
+
+        with tracer.start_as_current_span("baz") as baz:
+            time.sleep(0.3)
+            baz.set_attribute("name", "mauricio")
+
+        time.sleep(0.2)
+
+    time.sleep(0.1)

--- a/opentelemetry-python/manual-instrumentation/jaeger_exporter_grpc.sh
+++ b/opentelemetry-python/manual-instrumentation/jaeger_exporter_grpc.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+python $OTEL_WORKDIR/manual-instrumentation/jaeger_exporter_grpc.py

--- a/opentelemetry-python/manual-instrumentation/jaeger_exporter_thrift.py
+++ b/opentelemetry-python/manual-instrumentation/jaeger_exporter_thrift.py
@@ -1,0 +1,43 @@
+import time
+
+from opentelemetry import trace
+from opentelemetry.exporter.jaeger import thrift
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import (BatchSpanProcessor,ConsoleSpanExporter)
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+
+trace.set_tracer_provider(TracerProvider(
+    resource=Resource.create({SERVICE_NAME: "python-thrift-manual"})
+    ))
+tracer = trace.get_tracer(__name__)
+
+jaeger_exporter = thrift.JaegerExporter(
+    collector_endpoint="http://tempo:14268/api/traces?format=jaeger.thrift",
+)
+
+trace.get_tracer_provider().add_span_processor(
+    BatchSpanProcessor(ConsoleSpanExporter())
+)
+
+trace.get_tracer_provider().add_span_processor(
+    BatchSpanProcessor(jaeger_exporter)
+)
+
+# create some spans for testing
+with tracer.start_as_current_span("foo") as foo:
+    time.sleep(0.1)
+    foo.set_attribute("my_atribbute", True)
+    foo.add_event("event in foo", {"name": "foo1"})
+    with tracer.start_as_current_span(
+        "bar", links=[trace.Link(foo.get_span_context())]
+    ) as bar:
+        time.sleep(0.2)
+        bar.set_attribute("speed", 100.0)
+
+        with tracer.start_as_current_span("baz") as baz:
+            time.sleep(0.3)
+            baz.set_attribute("name", "mauricio")
+
+        time.sleep(0.2)
+
+    time.sleep(0.1)

--- a/opentelemetry-python/manual-instrumentation/jaeger_exporter_thrift.sh
+++ b/opentelemetry-python/manual-instrumentation/jaeger_exporter_thrift.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+python $OTEL_WORKDIR/manual-instrumentation/jaeger_exporter_thrift.py

--- a/opentelemetry-python/tempo.yaml
+++ b/opentelemetry-python/tempo.yaml
@@ -1,0 +1,34 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:                           # this configuration will listen on all ports and protocols that tempo is capable of.
+    jaeger:                            # the receives all come from the OpenTelemetry collector.  more configuration information can
+      protocols:                       # be found there: https://github.com/open-telemetry/opentelemetry-collector/tree/master/receiver
+        grpc:                          # for a production deployment you should only enable the receivers you need!
+        thrift_http:
+  log_received_traces: true
+
+ingester:
+  trace_idle_period: 10s               # the length of time after a trace has not received spans to consider it complete and flush it
+  max_block_duration: 5m               #   this much time passes
+
+compactor:
+  compaction:
+    compaction_window: 1h              # blocks in this time window will be compacted together
+    max_compaction_objects: 1000000    # maximum size of compacted blocks
+    block_retention: 1h
+    compacted_block_retention: 10m
+
+storage:
+  trace:
+    backend: local                     # backend configuration to use
+    wal:
+      path: /tmp/tempo/wal            # where to store the the wal locally
+    local:
+      path: /tmp/tempo/blocks
+    pool:
+      max_workers: 100                 # the worker pool mainly drives querying, but is also used for polling the blocklist
+      queue_depth: 10000


### PR DESCRIPTION
 增加 opentelemetry python 使用 demo，后端使用 Jaeger。包含手动、自动模式，协议使用 `gRPC`、`thrift http`。